### PR TITLE
Add context engineering tutorial post

### DIFF
--- a/content/blog/2026-04-18-context-engineering-interactive-tutorial.md
+++ b/content/blog/2026-04-18-context-engineering-interactive-tutorial.md
@@ -1,0 +1,21 @@
+---
+title: "Context Engineering: An Interactive Tutorial"
+date: 2026-04-18
+slug: "context-engineering-interactive-tutorial"
+tags: ["context engineering", "ai"]
+draft: false
+---
+
+In my day-to-day work I spend quite a lot of time talking to engineers about AI coding agents. And one thing that keeps coming up is context engineering — people sort of know the term, but struggle to apply it in practice. 
+
+So I built a small interactive tutorial to help with exactly that: [Context Engineering](https://blog.cloud-eng.nl/context-engineering/).
+
+It's a self-paced, browser-based walkthrough that covers the foundational ideas — what context is, how the agent loop works, why context degrades over time (yes, "context rot" is a real thing), and practical techniques for keeping it focused and effective. It also touches on memory, compaction, `AGENTS.md`, and observability.
+
+No setup, no installs — just open the link and go.
+
+If you spot something wrong, have a suggestion, or want to see a new topic covered, [file an issue on GitHub](https://github.com/asizikov/context-engineering/issues).
+
+## Disclosure
+
+> *I'm employed by GitHub at the time of writing this post. All opinions are my own.*


### PR DESCRIPTION
## Summary
Add a short announcement post for the new Context Engineering interactive tutorial.

## What changed
- add a new blog post under `content/blog/`
- explain the motivation behind the project
- link readers to the tutorial and GitHub issues page

## Why
I often see engineers struggle to understand and apply context engineering in practice, so this post introduces the tutorial as a lightweight way to learn the concept.