### PR TITLE
Improve post layout structure

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="{{ or site.Language.LanguageCode site.Language.Lang }}" dir="{{ or site.Language.LanguageDirection `ltr` }}">
+<head>
+  {{ partial "head.html" . }}
+</head>
+<body>
+  <header>
+    {{ partial "header.html" . }}
+  </header>
+  <main>
+    <div class="international__typo__main__layout">
+      <div class="international__typo__main__layout__left"></div>
+      <div class="international__typo__main__layout__right">
+        <div class="international__typo__main__layout__right__content">
+          {{ block "main" . }}{{ end }}
+        </div>
+        <footer class="international__typo__site__footer">
+          {{ partial "footer.html" . }}
+        </footer>
+      </div>
+    </div>
+  </main>
+</body>
+<script>(function (d, e) { d[e] = d[e].replace("no-js", "js"); })(document.documentElement, "className");</script>
+<script>
+    {{ $date := now.Format "2006-01-02" }}
+    {{ if .GitInfo }}
+    {{ $date = .GitInfo.AuthorDate }}
+    {{ end }}
+    {{ with .Site.Params.GoogleAnalytics }}
+        (function (i, s, o, g, r, a, m) { i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () { (i[r].q = i[r].q || []).push(arguments) }, i[r].l = 1 * new Date(); a = s.createElement(o), m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m) })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga'); ga('create', '{{ . }}', 'auto'); ga('send', 'pageview');
+    {{ end }}
+
+    {{ $rawSw := readFile "assets/js/sw.js" }}
+    {{ $buildDate := delimit (slice "const BUILD_DATE = \"" $date "\"") "" }}
+    {{ $swString := delimit (slice $buildDate $rawSw) ";   " }}
+    {{ $sw := $swString | resources.FromString "/sw.js" }}
+
+    if ('serviceWorker' in navigator) {
+        const buildDate = {{ $date | time.Format ":date_short" }};
+        navigator.serviceWorker
+            .register({{ $sw.Permalink }}, { scope: '/' })
+            .then(function (registration) {
+                console.log('Service Worker Registered');
+            });
+
+        navigator.serviceWorker
+            .ready
+            .then(function (registration) {
+                console.log('Service Worker Ready');
+            });
+    }
+</script>
+</html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,13 @@
+<div class="international__typo__header__layout">
+    <div class="international__typo__header__layout__left">
+        <span class="international__typo__header__layout_subdomain">
+            <a class="international__typo__header__home" href="/">blog.</a>
+        </span>
+    </div>
+    <div class="international__typo__header__layout__right">
+        <span class="international__typo__header__layout__right__domain">cloud-eng</span>
+        <span class="international__typo__header__layout__right__tld">.nl</span>
+    </div>
+</div>
+<!-- <h1>{{ site.Title }}</h1> -->
+<!-- {{ partial "menu.html" (dict "menuID" "main" "page" .) }} -->

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -31,6 +31,61 @@ body::after {
   font-weight: 500;
 }
 
+html {
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  height: auto;
+  justify-content: flex-start;
+  align-items: stretch;
+}
+
+main {
+  display: flex;
+  flex: 1 0 auto;
+}
+
+.international__typo__main__layout {
+  flex: 1 0 auto;
+  min-height: 100%;
+}
+
+.international__typo__main__layout__left {
+  min-height: 100%;
+}
+
+.international__typo__main__layout__right {
+  flex: 1 1 auto;
+  min-height: 100%;
+}
+
+.international__typo__main__layout__right__content {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
+  height: auto;
+  min-height: 0;
+}
+
+.international__typo__post__content {
+  flex: 1 0 auto;
+  height: auto;
+  min-height: 0;
+}
+
+.international__typo__site__footer {
+  margin-top: auto;
+  width: fit-content;
+  align-self: center;
+  padding-top: 1rem;
+}
+
+.international__typo__site__footer p {
+  margin: 0;
+}
+
 /* Mobile viewport meta fixes */
 @media screen and (max-width: 768px) {
   /* Reduce header font size significantly for mobile */
@@ -209,9 +264,9 @@ body::after {
   }
 
   /* Better footer spacing on mobile */
-  footer {
-    margin: 2rem 0 1rem 0;
-    padding: 1rem 20px;
+  .international__typo__site__footer {
+    margin: 2rem auto 1rem;
+    padding: 1rem 20px 0;
   }
 
   /* Ensure text doesn't get too close to screen edges */


### PR DESCRIPTION
This changes the post layout so the sidebar and footer behave more predictably without editing the upstream theme directly.

The main approach is to override the theme locally: a custom `baseof` moves the footer into the right-hand content column so it can be positioned relative to the post layout, a local header partial fixes the malformed theme markup, and the custom CSS updates the column sizing and footer spacing to keep the sidebar spanning the layout and the copyright block anchored cleanly.

A few details are worth noting:
- the fixes are intentionally kept in `layouts/` and `static/css/custom.css` so the theme itself stays untouched
- the last experimental flex-basis change was reverted, so this PR contains only the version that works correctly for larger pages
- the remaining behavior for very short posts is the current tradeoff of a top-aligned article with a pinned footer