### PR TITLE
Redesign Hugo blog layout and taxonomy pages

### DIFF
--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -1,0 +1,82 @@
+{{ define "main" }}
+{{- $mainSections := .Site.Params.mainSections }}
+{{- $pages := where .Site.RegularPages "Type" "in" $mainSections }}
+{{- $featured := index $pages 0 }}
+{{- $rest := after 1 $pages }}
+{{- $heroTitle := .Site.Params.Hero.title | default .Site.Title }}
+
+<section class="hero">
+  <div class="hero__inner">
+    <p class="hero__eyebrow">Notes from the field &mdash; cloud, GitHub, AI agents</p>
+    <h1 class="hero__title">
+      Hi, I&rsquo;m <span class="hero__name">{{ $heroTitle }}</span>.
+      <span class="hero__line">I write about shipping software</span>
+      <span class="hero__line hero__line--accent">in the age of AI.</span>
+    </h1>
+    <div class="hero__meta">
+      <a class="hero__cta" href="#latest">Read the latest &darr;</a>
+      <span class="hero__count">{{ len $pages }} posts &middot; updated {{ (index $pages 0).Date.Format "Jan 2006" }}</span>
+    </div>
+  </div>
+</section>
+
+{{ with .Content }}
+<section class="intro">
+  <div class="intro__inner">{{ . }}</div>
+</section>
+{{ end }}
+
+{{ with $featured }}
+<section class="featured" id="latest">
+  <div class="featured__label">
+    <span class="featured__tag">Latest</span>
+    <span class="featured__rule" aria-hidden="true"></span>
+  </div>
+  <a class="featured__card" href="{{ .RelPermalink }}">
+    <p class="featured__date">
+      <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 2, 2006" }}</time>
+      {{ with .Params.tags }}
+        <span class="featured__tags">
+          {{ range first 3 . }}<span class="featured__chip">{{ . }}</span>{{ end }}
+        </span>
+      {{ end }}
+    </p>
+    <h2 class="featured__title">{{ .Title }}</h2>
+    <p class="featured__summary">{{ .Summary | plainify | truncate 240 }}</p>
+    <span class="featured__more">Read post <span aria-hidden="true">&rarr;</span></span>
+  </a>
+</section>
+{{ end }}
+
+{{ with $rest }}
+<section class="archive">
+  <header class="archive__header">
+    <h2 class="archive__heading">The archive</h2>
+    <p class="archive__sub">Everything else, newest first.</p>
+  </header>
+
+  {{- $byYear := .GroupByDate "2006" }}
+  {{ range $byYear }}
+    <div class="year">
+      <div class="year__label">{{ .Key }}</div>
+      <ol class="year__list">
+        {{ range .Pages }}
+          <li class="entry">
+            <a class="entry__link" href="{{ .RelPermalink }}">
+              <time class="entry__date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 02" }}</time>
+              <h3 class="entry__title">{{ .Title }}</h3>
+              <p class="entry__summary">{{ .Summary | plainify | truncate 160 }}</p>
+              {{ with .Params.tags }}
+                <ul class="entry__tags">
+                  {{ range first 3 . }}<li>{{ . }}</li>{{ end }}
+                </ul>
+              {{ end }}
+            </a>
+          </li>
+        {{ end }}
+      </ol>
+    </div>
+  {{ end }}
+</section>
+{{ end }}
+{{ end }}

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -63,14 +63,16 @@
         {{ range .Pages }}
           <li class="entry">
             <a class="entry__link" href="{{ .RelPermalink }}">
-              <time class="entry__date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 02" }}</time>
+              <div class="entry__header">
+                <time class="entry__date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 02" }}</time>
+                {{ with .Params.tags }}
+                  <ul class="entry__tags">
+                    {{ range first 3 . }}<li>{{ . }}</li>{{ end }}
+                  </ul>
+                {{ end }}
+              </div>
               <h3 class="entry__title">{{ .Title }}</h3>
               <p class="entry__summary">{{ .Summary | plainify | truncate 160 }}</p>
-              {{ with .Params.tags }}
-                <ul class="entry__tags">
-                  {{ range first 3 . }}<li>{{ . }}</li>{{ end }}
-                </ul>
-              {{ end }}
             </a>
           </li>
         {{ end }}

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -52,7 +52,6 @@
 <section class="archive">
   <header class="archive__header">
     <h2 class="archive__heading">The archive</h2>
-    <p class="archive__sub">Everything else, newest first.</p>
   </header>
 
   {{- $byYear := .GroupByDate "2006" }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,12 +2,13 @@
 <div class="international__typo__post__content">
   <h1>{{ .Title }}</h1>
 
-  {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
-  {{ $dateHuman := .Date | time.Format ":date_long" }}
-  
-  <p class="international__typo__post__date">
-    Published on <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
-  </p>
+  {{ if not .Params.page }}
+    {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
+    {{ $dateHuman := .Date | time.Format ":date_long" }}
+    <p class="international__typo__post__date">
+      Published on <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+    </p>
+  {{ end }}
 
   {{ .Content }}
   {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,67 @@
+{{ define "main" }}
+{{ if eq .Kind "taxonomy" }}
+  {{/* /tags/ — list of all tags */}}
+  <section class="taxonomy">
+    <header class="taxonomy__header">
+      <p class="taxonomy__eyebrow">Browse by tag</p>
+      <h1 class="taxonomy__title">{{ .Title }}</h1>
+      <p class="taxonomy__sub">{{ len .Pages }} tags &middot; click any to see related posts.</p>
+    </header>
+
+    {{ $terms := .Data.Terms.ByCount }}
+    <ul class="tagcloud">
+      {{ range $terms }}
+        <li>
+          <a class="tagcloud__item" href="{{ .Page.RelPermalink }}">
+            <span class="tagcloud__name">{{ .Page.LinkTitle | lower }}</span>
+            <span class="tagcloud__count">{{ .Count }}</span>
+          </a>
+        </li>
+      {{ end }}
+    </ul>
+  </section>
+{{ else if eq .Kind "term" }}
+  {{/* /tags/foo/ — single tag's posts */}}
+  <section class="term">
+    <header class="term__header">
+      <p class="term__eyebrow"><a href="/tags/">All tags</a> &nbsp;/&nbsp; tag</p>
+      <h1 class="term__title">#{{ .Title | lower }}</h1>
+      <p class="term__sub">{{ len .Pages }} post{{ if ne (len .Pages) 1 }}s{{ end }} tagged with <strong>{{ .Title | lower }}</strong>.</p>
+    </header>
+
+    {{- $byYear := .Pages.GroupByDate "2006" }}
+    {{ range $byYear }}
+      <div class="year">
+        <div class="year__label">{{ .Key }}</div>
+        <ol class="year__list">
+          {{ range .Pages }}
+            <li class="entry">
+              <a class="entry__link" href="{{ .RelPermalink }}">
+                <div class="entry__header">
+                  <time class="entry__date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 02" }}</time>
+                  {{ with .Params.tags }}
+                    <ul class="entry__tags">
+                      {{ range first 3 . }}<li>{{ . }}</li>{{ end }}
+                    </ul>
+                  {{ end }}
+                </div>
+                <h3 class="entry__title">{{ .Title }}</h3>
+                <p class="entry__summary">{{ .Summary | plainify | truncate 160 }}</p>
+              </a>
+            </li>
+          {{ end }}
+        </ol>
+      </div>
+    {{ end }}
+  </section>
+{{ else }}
+  {{/* generic list fallback */}}
+  <section class="taxonomy">
+    <h1 class="taxonomy__title">{{ .Title }}</h1>
+    {{ .Content }}
+    {{ range .Pages }}
+      <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
+    {{ end }}
+  </section>
+{{ end }}
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,7 +17,7 @@
 		name="search engines">
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700;9..144,900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 	{{ with .Site.Params.adsenseId }}
 	<script data-ad-client="{{ . }}" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
     {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,10 @@
     <div class="international__typo__header__layout__right">
         <span class="international__typo__header__layout__right__domain">cloud-eng</span>
         <span class="international__typo__header__layout__right__tld">.nl</span>
+        <nav class="header__nav">
+            {{ range site.Menus.main }}
+            <a class="header__nav__link" href="{{ .URL }}">{{ .Name }}</a>
+            {{ end }}
+        </nav>
     </div>
 </div>
-<!-- <h1>{{ site.Title }}</h1> -->
-<!-- {{ partial "menu.html" (dict "menuID" "main" "page" .) }} -->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,7 +9,7 @@
         <span class="international__typo__header__layout__right__tld">.nl</span>
         <nav class="header__nav">
             {{ range site.Menus.main }}
-            <a class="header__nav__link" href="{{ .URL }}">{{ .Name }}</a>
+            <a class="header__nav__link" href="{{ .URL }}">{{ or .Name .Identifier }}</a>
             {{ end }}
         </nav>
     </div>

--- a/layouts/partials/terms.html
+++ b/layouts/partials/terms.html
@@ -1,0 +1,13 @@
+{{- $page := .page }}
+{{- $taxonomy := .taxonomy }}
+
+{{- with $page.GetTerms $taxonomy }}
+  <div class="post__terms">
+    <span class="post__terms__label">Tagged</span>
+    <ul class="post__terms__list">
+      {{- range . }}
+        <li><a href="{{ .RelPermalink }}">#{{ .LinkTitle | lower }}</a></li>
+      {{- end }}
+    </ul>
+  </div>
+{{- end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -80,7 +80,7 @@ header {
   width: auto;
   background-color: var(--secondary-color);
   color: var(--primary-color);
-  padding: 0.45em 0 0.45em 0.7em; /* zero right padding — domain reads flush */
+  padding: 0 0 0 0.7em; /* vertical centering via align-items; no top/bottom padding */
   display: inline-flex;
   align-items: center;
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -12,6 +12,7 @@
   --text-color: #1a1a1a;
   --muted-color: #555;
   --rule-color: rgba(10, 10, 10, 0.14);
+  --header-bar-height: 72px;
 
   --font-sans: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-display: "Fraunces", Georgia, "Times New Roman", serif;
@@ -70,6 +71,7 @@ header {
   display: flex;
   align-items: stretch;
   width: 100%;
+  min-height: var(--header-bar-height);
   font-size: 28px;
   font-family: var(--font-sans);
   font-weight: 800;
@@ -83,6 +85,8 @@ header {
   padding: 0 0 0 0.7em; /* vertical centering via align-items; no top/bottom padding */
   display: inline-flex;
   align-items: center;
+  min-height: var(--header-bar-height);
+  box-sizing: border-box;
 }
 
 .international__typo__header__home { color: var(--primary-color); font-weight: 800; }
@@ -96,6 +100,8 @@ header {
   padding: 0 0.7em 0 0;
   white-space: nowrap;
   background: transparent;
+  min-height: var(--header-bar-height);
+  box-sizing: border-box;
 }
 
 /* nav links pushed to the far right */
@@ -599,6 +605,7 @@ header {
 }
 
 @media (max-width: 640px) {
+  :root { --header-bar-height: 64px; }
   .international__typo__header__layout { font-size: 22px; }
   .hero__title { font-size: clamp(2.2rem, 11vw, 3.2rem); }
   .hero__cta { padding: 12px 18px; font-size: 14px; }
@@ -612,6 +619,165 @@ header {
   .featured { padding-left: 16px; padding-right: 16px; }
   .hero { padding-left: 20px; padding-right: 20px; }
   .intro { padding-left: 20px; padding-right: 20px; }
+  .taxonomy, .term { padding-left: 16px !important; padding-right: 16px !important; }
+}
+
+/* ---------- TAXONOMY (/tags/) — tag cloud ---------- */
+.taxonomy {
+  padding: clamp(48px, 7vw, 96px) clamp(20px, 6vw, 80px) clamp(64px, 8vw, 120px);
+  max-width: var(--content-max);
+  margin: 0 auto;
+  width: 100%;
+  box-sizing: border-box;
+}
+.taxonomy__header { margin-bottom: clamp(32px, 5vw, 56px); }
+.taxonomy__eyebrow {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--secondary-color);
+  opacity: 0.7;
+  margin: 0 0 12px;
+}
+.taxonomy__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.4rem, 6vw, 4.5rem);
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+  margin: 0 0 16px;
+  color: var(--secondary-color);
+}
+.taxonomy__sub {
+  font-family: var(--font-display);
+  font-size: clamp(1.05rem, 1.5vw, 1.25rem);
+  color: var(--muted-color);
+  margin: 0;
+}
+
+.tagcloud {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.tagcloud__item {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--tertiary-color);
+  border: 2px solid var(--secondary-color);
+  border-radius: 999px;
+  color: var(--secondary-color);
+  font-weight: 600;
+  transition: transform 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.tagcloud__item:hover {
+  text-decoration: none;
+  background: var(--secondary-color);
+  color: var(--primary-color);
+  transform: translateY(-2px);
+}
+.tagcloud__item:hover .tagcloud__count {
+  color: var(--primary-color);
+  border-color: var(--primary-color);
+}
+.tagcloud__name {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  letter-spacing: -0.01em;
+}
+.tagcloud__count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted-color);
+  border: 1px solid var(--rule-color);
+  padding: 1px 7px;
+  border-radius: 999px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+/* ---------- TERM (/tags/foo/) — single tag's posts ---------- */
+.term {
+  padding: clamp(48px, 7vw, 96px) clamp(20px, 6vw, 80px) clamp(64px, 8vw, 120px);
+  max-width: var(--content-max);
+  margin: 0 auto;
+  width: 100%;
+  box-sizing: border-box;
+}
+.term__header { margin-bottom: clamp(28px, 4vw, 48px); }
+.term__eyebrow {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--secondary-color);
+  opacity: 0.7;
+  margin: 0 0 12px;
+}
+.term__eyebrow a { color: var(--secondary-color); font-weight: 600; }
+.term__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.4rem, 6vw, 4.5rem);
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+  margin: 0 0 14px;
+  color: var(--secondary-color);
+}
+.term__sub {
+  font-family: var(--font-display);
+  font-size: clamp(1.05rem, 1.5vw, 1.25rem);
+  color: var(--muted-color);
+  margin: 0;
+}
+.term__sub strong { color: var(--secondary-color); font-weight: 600; }
+
+/* ---------- inline post tags (bottom of single post) ---------- */
+.post__terms {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--rule-color);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.post__terms__label {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted-color);
+}
+.post__terms__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.post__terms__list a {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--secondary-color);
+  background: rgba(10, 10, 10, 0.06);
+  padding: 4px 10px;
+  border-radius: 4px;
+  transition: background 0.15s, color 0.15s;
+}
+.post__terms__list a:hover {
+  text-decoration: none;
+  background: var(--secondary-color);
+  color: var(--primary-color);
 }
 
 /* Re-enable inline link tap targets sensibly on touch (no giant blocks) */

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -63,6 +63,7 @@ header {
   background: var(--primary-color);
   background: var(--primary-fallback);
   border-bottom: 2px solid var(--secondary-color);
+  overflow: hidden; /* prevent black box bleeding below */
 }
 
 .international__typo__header__layout {
@@ -79,7 +80,7 @@ header {
   width: auto;
   background-color: var(--secondary-color);
   color: var(--primary-color);
-  padding: 0.45em 0.7em;
+  padding: 0.45em 0.5em 0.45em 0.7em; /* no right padding — domain reads flush */
   display: inline-flex;
   align-items: center;
 }
@@ -91,7 +92,7 @@ header {
   width: auto;
   display: inline-flex;
   align-items: center;
-  padding: 0 0.7em;
+  padding: 0 0.7em 0 0.15em; /* minimal left gap so domain reads as one unit */
   white-space: nowrap;
   background: transparent;
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,292 +1,596 @@
-/* Mobile-first responsive fixes for international-typo theme */
+/* =========================================================
+   Redesign — modern, typography-heavy, palette preserved
+   primary: yellow (#ffc833 / display-p3 1 .784 .2)
+   secondary: black, tertiary: white, text: #1a1a1a
+   ========================================================= */
 
-/* === Desktop fixes === */
+:root {
+  --primary-color: color(display-p3 1 0.784 0.2);
+  --primary-fallback: #ffc833;
+  --secondary-color: #0a0a0a;
+  --tertiary-color: #ffffff;
+  --text-color: #1a1a1a;
+  --muted-color: #555;
+  --rule-color: rgba(10, 10, 10, 0.14);
 
-/* #2: Keep post content wide, but not wall-to-wall on large screens */
-.international__typo__post__content {
-  width: 100%;
-  /* Cap line length on large screens (roughly “long title” width) */
-  max-width: 75rem;
+  --font-sans: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-display: "Fraunces", Georgia, "Times New Roman", serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  --content-max: 1180px;
+  --reading-max: 68ch;
 }
 
-/* #3: Widen post list items for better scannability */
-.international__typo__post__block {
-  width: 75%;
-}
-
-/* #4: Remove distracting grid overlay */
-body::after {
-  display: none;
-}
-
-/* #7: Style published date as secondary information */
-.international__typo__post__date {
-  font-size: 0.9rem;
-  color: #555;
-  margin-bottom: 1.5rem;
-  font-weight: normal;
-}
-
-.international__typo__post__date time {
-  font-weight: 500;
-}
-
-html {
-  min-height: 100%;
-}
+/* ---------- global resets / base ---------- */
+html { min-height: 100%; -webkit-text-size-adjust: 100%; }
 
 body {
+  font-family: var(--font-sans);
+  font-size: 18px;
+  line-height: 1.6;
+  background-color: var(--primary-fallback);
+  background-color: var(--primary-color);
+  color: var(--text-color);
   min-height: 100vh;
   height: auto;
-  justify-content: flex-start;
-  align-items: stretch;
-}
-
-main {
-  display: flex;
-  flex: 1 0 auto;
-}
-
-.international__typo__main__layout {
-  flex: 1 0 auto;
-  min-height: 100%;
-}
-
-.international__typo__main__layout__left {
-  min-height: 100%;
-}
-
-.international__typo__main__layout__right {
-  flex: 1 1 auto;
-  min-height: 100%;
-}
-
-.international__typo__main__layout__right__content {
   display: flex;
   flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
+  margin: 0;
+  padding: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* Kill the grid overlay from the theme */
+body::after { display: none !important; }
+
+a { color: var(--secondary-color); font-weight: 600; text-decoration: none; }
+a:hover { text-decoration: underline; text-underline-offset: 4px; text-decoration-thickness: 2px; }
+
+img { max-width: 100%; height: auto; box-shadow: none; border-radius: 4px; }
+
+main { display: flex; flex: 1 0 auto; width: 100%; }
+
+/* ---------- header (preserve theme markup, refine look) ---------- */
+header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  width: 100%;
+  background: var(--primary-color);
+  background: var(--primary-fallback);
+  border-bottom: 2px solid var(--secondary-color);
+}
+
+.international__typo__header__layout {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  font-size: 28px;
+  font-family: var(--font-sans);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.international__typo__header__layout__left {
+  width: auto;
+  background-color: var(--secondary-color);
+  color: var(--primary-color);
+  padding: 0.45em 0.7em;
+  display: inline-flex;
+  align-items: center;
+}
+
+.international__typo__header__home { color: var(--primary-color); font-weight: 800; }
+.international__typo__header__home:hover { color: var(--tertiary-color); text-decoration: none; }
+
+.international__typo__header__layout__right {
+  width: auto;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.7em;
+  white-space: nowrap;
+  background: transparent;
+}
+
+.international__typo__header__layout__right__domain { color: var(--secondary-color); }
+.international__typo__header__layout__right__tld {
+  color: var(--secondary-color);
+  border: 2px dotted var(--secondary-color);
+  padding: 0 0.2em;
+  margin-left: 2px;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+/* ---------- main layout overrides — kill the side rail ---------- */
+.international__typo__main__layout {
+  display: block;
+  width: 100%;
   flex: 1 0 auto;
+}
+.international__typo__main__layout__left { display: none; }
+.international__typo__main__layout__right {
+  display: block;
+  width: 100%;
+  padding: 0;
+}
+.international__typo__main__layout__right__content {
+  display: block;
+  padding: 0;
   height: auto;
   min-height: 0;
 }
 
-.international__typo__post__content {
-  flex: 1 0 auto;
-  height: auto;
-  min-height: 0;
+/* ---------- HERO ---------- */
+.hero {
+  position: relative;
+  padding: clamp(48px, 9vw, 120px) clamp(20px, 6vw, 80px) clamp(40px, 7vw, 96px);
+  border-bottom: 2px solid var(--secondary-color);
+  overflow: hidden;
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: auto -10% -45% auto;
+  width: 70%;
+  aspect-ratio: 1 / 1;
+  background: radial-gradient(circle at center, rgba(0,0,0,0.06), transparent 60%);
+  pointer-events: none;
+}
+.hero__inner {
+  max-width: var(--content-max);
+  margin: 0 auto;
+  position: relative;
+}
+.hero__eyebrow {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--secondary-color);
+  margin: 0 0 clamp(20px, 3vw, 32px);
+  opacity: 0.75;
+}
+.hero__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2.6rem, 8vw, 6.5rem);
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+  margin: 0;
+  color: var(--secondary-color);
+  font-variation-settings: "opsz" 144, "SOFT" 0;
+}
+.hero__name {
+  font-style: italic;
+  font-weight: 600;
+  position: relative;
+  white-space: nowrap;
+}
+.hero__name::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: 0.05em;
+  height: 0.18em;
+  background: var(--secondary-color);
+  opacity: 0.12;
+  border-radius: 2px;
+}
+.hero__line { display: block; }
+.hero__line--accent {
+  font-style: italic;
+  font-weight: 400;
+  color: var(--secondary-color);
+  position: relative;
+}
+.hero__line--accent::before {
+  content: "";
+  display: inline-block;
+  width: 0.55em;
+  height: 0.55em;
+  background: var(--secondary-color);
+  border-radius: 50%;
+  margin-right: 0.25em;
+  vertical-align: 0.2em;
 }
 
-.international__typo__site__footer {
-  margin-top: auto;
-  width: fit-content;
-  align-self: center;
-  padding-top: 1rem;
+.hero__meta {
+  margin-top: clamp(28px, 4vw, 44px);
+  display: flex;
+  align-items: center;
+  gap: clamp(16px, 3vw, 32px);
+  flex-wrap: wrap;
+}
+.hero__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--secondary-color);
+  color: var(--primary-color);
+  padding: 14px 22px;
+  font-weight: 700;
+  border-radius: 999px;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+.hero__cta:hover {
+  text-decoration: none;
+  transform: translateY(-1px);
+  background: #1d1d1d;
+}
+.hero__count {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--secondary-color);
+  opacity: 0.7;
+  letter-spacing: 0.02em;
 }
 
-.international__typo__site__footer p {
+/* ---------- intro paragraph (from _index.md) ---------- */
+.intro {
+  background: var(--tertiary-color);
+  border-bottom: 2px solid var(--secondary-color);
+  padding: clamp(36px, 5vw, 64px) clamp(20px, 6vw, 80px);
+}
+.intro__inner {
+  max-width: var(--reading-max);
+  margin: 0 auto;
+  font-family: var(--font-display);
+  font-size: clamp(1.15rem, 1.6vw, 1.4rem);
+  line-height: 1.55;
+  color: var(--text-color);
+}
+.intro__inner p { margin: 0 0 0.75em; }
+.intro__inner p:last-child { margin-bottom: 0; }
+
+/* ---------- FEATURED ---------- */
+.featured {
+  padding: clamp(48px, 7vw, 96px) clamp(20px, 6vw, 80px) clamp(32px, 5vw, 64px);
+  max-width: var(--content-max);
+  margin: 0 auto;
+  width: 100%;
+  box-sizing: border-box;
+}
+.featured__label {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: clamp(20px, 3vw, 32px);
+}
+.featured__tag {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--secondary-color);
+  background: var(--secondary-color);
+  color: var(--primary-color);
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+.featured__rule {
+  flex: 1;
+  height: 2px;
+  background: var(--secondary-color);
+  opacity: 0.85;
+}
+
+.featured__card {
+  display: block;
+  color: var(--text-color);
+  font-weight: 400;
+  background: var(--tertiary-color);
+  border: 2px solid var(--secondary-color);
+  border-radius: 8px;
+  padding: clamp(28px, 4vw, 56px);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  box-shadow: 8px 8px 0 var(--secondary-color);
+}
+.featured__card:hover {
+  text-decoration: none;
+  transform: translate(-2px, -2px);
+  box-shadow: 12px 12px 0 var(--secondary-color);
+}
+.featured__date {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--muted-color);
+  margin: 0 0 18px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+.featured__tags { display: inline-flex; gap: 6px; flex-wrap: wrap; }
+.featured__chip {
+  background: var(--primary-color);
+  background-color: var(--primary-fallback);
+  color: var(--secondary-color);
+  border: 1px solid var(--secondary-color);
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  text-transform: lowercase;
+}
+.featured__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  margin: 0 0 18px;
+  color: var(--secondary-color);
+}
+.featured__card:hover .featured__title { text-decoration: none; }
+.featured__summary {
+  font-family: var(--font-display);
+  font-size: clamp(1.05rem, 1.4vw, 1.25rem);
+  line-height: 1.55;
+  color: var(--muted-color);
+  margin: 0 0 24px;
+  max-width: 60ch;
+}
+.featured__more {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--secondary-color);
+  border-bottom: 2px solid var(--secondary-color);
+  padding-bottom: 2px;
+}
+
+/* ---------- ARCHIVE ---------- */
+.archive {
+  padding: clamp(32px, 5vw, 72px) clamp(20px, 6vw, 80px) clamp(64px, 8vw, 120px);
+  max-width: var(--content-max);
+  margin: 0 auto;
+  width: 100%;
+  box-sizing: border-box;
+}
+.archive__header { margin-bottom: clamp(28px, 4vw, 48px); }
+.archive__heading {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(1.8rem, 3.2vw, 2.6rem);
+  letter-spacing: -0.02em;
+  margin: 0 0 6px;
+  color: var(--secondary-color);
+}
+.archive__sub {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  color: var(--secondary-color);
+  opacity: 0.7;
   margin: 0;
 }
 
-/* Mobile viewport meta fixes */
-@media screen and (max-width: 768px) {
-  /* Reduce header font size significantly for mobile */
-  :root {
-    --header-font-size: 24px;
-    --post-text-size: 16px;
-  }
-
-  /* Make header responsive */
-  .international__typo__header__layout {
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 0.15em;
-    font-size: var(--header-font-size);
-    padding: 10px 12px;
-    flex-wrap: nowrap;
-    width: 100%;
-  }
-
-  .international__typo__header__layout__left {
-    width: auto;
-    min-width: 0;
-    justify-content: flex-start;
-    padding: 0.15em 0.35em;
-    background-color: var(--secondary-color);
-    flex-shrink: 0;
-  }
-
-  .international__typo__header__layout__right {
-    width: auto;
-    min-width: 0;
-    justify-content: flex-start;
-    padding: 0;
-    background-color: transparent;
-    flex-shrink: 0;
-  }
-
-  /* Make all header text properly colored */
-  .international__typo__header__layout__left .international__typo__header__home {
-    color: var(--primary-color);
-  }
-
-  .international__typo__header__layout__right__domain,
-  .international__typo__header__layout__right__tld {
-    color: var(--secondary-color);
-    font-weight: normal;
-  }
-
-  .international__typo__header__layout__right__tld {
-    border: 1px dotted var(--secondary-color);
-    font-weight: bold;
-    padding: 0 0.15em;
-    line-height: 1;
-  }
-
-  /* Undo the global mobile link sizing for the header only (prevents huge blocks) */
-  .international__typo__header__layout a {
-    min-height: unset;
-    display: inline;
-    padding: 0;
-  }
-
-  /* Fix main layout for mobile */
-  .international__typo__main__layout {
-    flex-direction: column;
-  }
-
-  .international__typo__main__layout__left {
-    width: 100%;
-    height: auto;
-    display: none; /* Hide the empty left sidebar on mobile */
-  }
-
-  .international__typo__main__layout__right {
-    width: 100%;
-    padding: 20px 0 0 0;
-  }
-
-  .international__typo__main__layout__right__content {
-    padding: 0 20px;
-  }
-
-  /* Fix post blocks for mobile */
-  .international__typo__post__block {
-    flex-direction: column;
-    width: 100%;
-    margin-bottom: 30px;
-  }
-
-  .international__typo__post__block__left {
-    width: 100%;
-    margin-right: 0;
-    margin-bottom: 10px;
-    padding: 10px 0;
-    border-top: 2px solid #222;
-  }
-
-  .international__typo__post__block__right {
-    width: 100%;
-    margin-left: 0;
-    padding: 10px 0;
-    border-top: none; /* Remove duplicate border */
-  }
-
-  .international__typo__post__block__left__date {
-    font-size: 1rem;
-    margin-bottom: 5px;
-  }
-
-  /* Fix post content width */
-  .international__typo__post__content {
-    width: 100%;
-  }
-
-  /* Improve heading sizes for mobile */
-  h1 {
-    font-size: 1.8rem;
-    line-height: 1.2;
-  }
-
-  h2 {
-    font-size: 1.4rem;
-    line-height: 1.3;
-  }
-
-  /* Improve code block mobile handling */
-  .highlight {
-    margin: 1rem 0;
-    font-size: 14px;
-  }
-
-  /* Remove the grid overlay on mobile - it's too intrusive */
-  body::after {
-    display: none;
-  }
-
-  /* Ensure images are responsive */
-  img {
-    width: 100%;
-    height: auto;
-    max-width: 100%;
-  }
+.year {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: clamp(16px, 3vw, 48px);
+  border-top: 2px solid var(--secondary-color);
+  padding: clamp(24px, 3vw, 40px) 0;
+}
+.year__label {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: clamp(2.4rem, 5vw, 4rem);
+  letter-spacing: -0.04em;
+  color: var(--secondary-color);
+  line-height: 1;
+  position: sticky;
+  top: 90px;
+  align-self: start;
+}
+.year__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
 }
 
-/* Tablet adjustments */
-@media screen and (min-width: 769px) and (max-width: 1024px) {
-  :root {
-    --header-font-size: 60px;
-    --post-text-size: 18px;
-  }
-
-  .international__typo__main__layout__left {
-    width: 15%;
-  }
-
-  .international__typo__main__layout__right {
-    width: 85%;
-  }
-
-  .international__typo__post__block {
-    width: 70%;
-  }
-
-  .international__typo__post__content {
-    width: 100%;
-  }
+.entry {
+  border-top: 1px solid var(--rule-color);
+}
+.entry:first-child { border-top: none; }
+.entry__link {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 24px;
+  padding: clamp(18px, 2.4vw, 28px) 0;
+  color: var(--text-color);
+  font-weight: 400;
+  align-items: baseline;
+  transition: padding-left 0.18s ease;
+}
+.entry__link:hover {
+  text-decoration: none;
+  padding-left: 8px;
+}
+.entry__link:hover .entry__title {
+  text-decoration: underline;
+  text-underline-offset: 5px;
+  text-decoration-thickness: 2px;
+}
+.entry__date {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  color: var(--muted-color);
+  text-transform: uppercase;
+  white-space: nowrap;
+  padding-top: 0.4em;
+}
+.entry__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(1.4rem, 2.6vw, 2rem);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: var(--secondary-color);
+  margin: 0 0 8px;
+}
+.entry__summary {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--muted-color);
+  margin: 0;
+  max-width: 60ch;
+}
+.entry__tags {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.entry__tags li {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--secondary-color);
+  background: rgba(10, 10, 10, 0.06);
+  padding: 2px 8px;
+  border-radius: 4px;
+  text-transform: lowercase;
 }
 
-/* Improve general mobile touch targets and spacing */
-@media screen and (max-width: 768px) {
-  a {
-    min-height: 44px;
-    display: inline-block;
-    padding: 5px 0;
-  }
-
-  /* Better footer spacing on mobile */
-  .international__typo__site__footer {
-    margin: 2rem auto 1rem;
-    padding: 1rem 20px 0;
-  }
-
-  /* Ensure text doesn't get too close to screen edges */
-  body {
-    padding: 0;
-  }
+/* ---------- single post page ---------- */
+.international__typo__post__content {
+  width: 100%;
+  max-width: var(--reading-max);
+  margin: 0 auto;
+  padding: clamp(40px, 6vw, 80px) clamp(20px, 6vw, 40px) clamp(48px, 8vw, 96px);
+  background: transparent;
+  flex: 1 0 auto;
+}
+.international__typo__post__content h1 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  margin: 0 0 16px;
+  color: var(--secondary-color);
+}
+.international__typo__post__content h2,
+.international__typo__post__content h3,
+.international__typo__post__content h4 {
+  font-family: var(--font-display);
+  letter-spacing: -0.015em;
+  color: var(--secondary-color);
+  margin-top: 1.6em;
+}
+.international__typo__post__content h2 { font-size: 1.8rem; }
+.international__typo__post__content h3 { font-size: 1.35rem; }
+.international__typo__post__content p,
+.international__typo__post__content li {
+  font-size: 1.075rem;
+  line-height: 1.7;
+}
+.international__typo__post__content blockquote {
+  border-left: 4px solid var(--secondary-color);
+  padding: 0.2em 0 0.2em 1.2em;
+  margin: 1.5em 0;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.2rem;
+  color: var(--secondary-color);
+}
+.international__typo__post__content code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  background: rgba(10, 10, 10, 0.08);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+}
+.international__typo__post__content pre {
+  border-radius: 6px;
+  border: 1px solid var(--secondary-color);
+  padding: 1rem 1.2rem;
+  overflow-x: auto;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.international__typo__post__content pre code {
+  background: transparent;
+  padding: 0;
 }
 
-/* Improve very small screens (phones in portrait) */
-@media screen and (max-width: 480px) {
-  :root {
-    --header-font-size: 20px;
-    --post-text-size: 15px;
-  }
+.international__typo__post__date {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--muted-color);
+  margin-bottom: 2.4rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+.international__typo__post__date time { font-weight: 600; color: var(--secondary-color); }
 
-  .international__typo__main__layout__right__content {
-    padding: 0 15px;
-  }
+/* ---------- footer ---------- */
+.international__typo__site__footer {
+  margin-top: auto;
+  padding: 32px 20px;
+  text-align: center;
+  border-top: 2px solid var(--secondary-color);
+  background: var(--secondary-color);
+  color: var(--primary-color);
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  align-self: stretch;
+}
+.international__typo__site__footer p { margin: 0; }
+.international__typo__site__footer a { color: var(--primary-color); }
 
-  .international__typo__header__layout {
-    padding: 5px 15px;
+/* ---------- responsive ---------- */
+@media (max-width: 860px) {
+  .year {
+    grid-template-columns: 1fr;
+    gap: 16px;
   }
+  .year__label {
+    position: static;
+    font-size: 2.4rem;
+  }
+  .entry__link {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+  .entry__date { padding-top: 0; }
+}
+
+@media (max-width: 640px) {
+  .international__typo__header__layout { font-size: 22px; }
+  .hero__title { font-size: clamp(2.2rem, 11vw, 3.2rem); }
+  .hero__cta { padding: 12px 18px; font-size: 14px; }
+  .featured__card {
+    box-shadow: 5px 5px 0 var(--secondary-color);
+    padding: 22px;
+  }
+  .featured__card:hover { box-shadow: 8px 8px 0 var(--secondary-color); }
+  .featured__title { font-size: 1.8rem; }
+  .archive { padding-left: 16px; padding-right: 16px; }
+  .featured { padding-left: 16px; padding-right: 16px; }
+  .hero { padding-left: 20px; padding-right: 20px; }
+  .intro { padding-left: 20px; padding-right: 20px; }
+}
+
+/* Re-enable inline link tap targets sensibly on touch (no giant blocks) */
+@media (max-width: 768px) {
+  a { min-height: auto; display: inline; padding: 0; }
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -80,7 +80,7 @@ header {
   width: auto;
   background-color: var(--secondary-color);
   color: var(--primary-color);
-  padding: 0.45em 0.5em 0.45em 0.7em; /* no right padding — domain reads flush */
+  padding: 0.45em 0 0.45em 0.7em; /* zero right padding — domain reads flush */
   display: inline-flex;
   align-items: center;
 }
@@ -92,7 +92,7 @@ header {
   width: auto;
   display: inline-flex;
   align-items: center;
-  padding: 0 0.7em 0 0.15em; /* minimal left gap so domain reads as one unit */
+  padding: 0 0.7em 0 0; /* zero left gap so blog. butts against cloud-eng */
   white-space: nowrap;
   background: transparent;
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -89,12 +89,36 @@ header {
 .international__typo__header__home:hover { color: var(--tertiary-color); text-decoration: none; }
 
 .international__typo__header__layout__right {
-  width: auto;
+  flex: 1; /* fill remaining width so header is always full-width */
   display: inline-flex;
   align-items: center;
-  padding: 0 0.7em 0 0; /* zero left gap so blog. butts against cloud-eng */
+  gap: 0.5em;
+  padding: 0 0.7em 0 0;
   white-space: nowrap;
   background: transparent;
+}
+
+/* nav links pushed to the far right */
+.header__nav {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: clamp(12px, 2vw, 28px);
+}
+.header__nav__link {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--secondary-color);
+  letter-spacing: 0;
+  padding: 4px 0;
+  border-bottom: 2px solid transparent;
+  transition: border-color 0.15s;
+}
+.header__nav__link:hover,
+.header__nav__link.active {
+  text-decoration: none;
+  border-bottom-color: var(--secondary-color);
 }
 
 .international__typo__header__layout__right__domain { color: var(--secondary-color); }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -430,13 +430,12 @@ header {
 }
 .entry:first-child { border-top: none; }
 .entry__link {
-  display: grid;
-  grid-template-columns: 90px 1fr;
-  gap: 24px;
-  padding: clamp(18px, 2.4vw, 28px) 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: clamp(20px, 2.8vw, 32px) 0;
   color: var(--text-color);
   font-weight: 400;
-  align-items: baseline;
   transition: padding-left 0.18s ease;
 }
 .entry__link:hover {
@@ -448,6 +447,12 @@ header {
   text-underline-offset: 5px;
   text-decoration-thickness: 2px;
 }
+.entry__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
 .entry__date {
   font-family: var(--font-mono);
   font-size: 13px;
@@ -455,20 +460,19 @@ header {
   color: var(--muted-color);
   text-transform: uppercase;
   white-space: nowrap;
-  padding-top: 0.4em;
 }
 .entry__title {
   font-family: var(--font-display);
   font-weight: 700;
-  font-size: clamp(1.4rem, 2.6vw, 2rem);
-  line-height: 1.15;
+  font-size: clamp(1.3rem, 2.4vw, 1.8rem);
+  line-height: 1.2;
   letter-spacing: -0.02em;
   color: var(--secondary-color);
   margin: 0 0 8px;
 }
 .entry__summary {
   font-family: var(--font-sans);
-  font-size: 16px;
+  font-size: 15px;
   line-height: 1.55;
   color: var(--muted-color);
   margin: 0;
@@ -476,7 +480,7 @@ header {
 }
 .entry__tags {
   list-style: none;
-  margin: 12px 0 0;
+  margin: 0;
   padding: 0;
   display: flex;
   flex-wrap: wrap;
@@ -592,11 +596,6 @@ header {
     position: static;
     font-size: 2.4rem;
   }
-  .entry__link {
-    grid-template-columns: 1fr;
-    gap: 6px;
-  }
-  .entry__date { padding-top: 0; }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
This refreshes the Hugo site with a more modern, typography-heavy presentation while keeping the existing yellow / black / white palette intact. The goal is to make the homepage, reading experience, and tag navigation feel like one cohesive design rather than a thin theme override.

## What changed

- Rebuilt the homepage with a new hero, a featured latest-post section, and a cleaner archive layout grouped by year.
- Reworked the sticky header so the `blog.cloud-eng.nl` lockup reads as one domain, stays visually stable while scrolling, and leaves room for the right-side nav.
- Updated single-post presentation with stronger display typography, cleaner metadata, and improved inline tag styling.
- Redesigned `/tags/` into a tag cloud and `/tags/<term>/` into a matching archive-style listing instead of the default plain lists.
- Hid publish dates for standalone pages like About where Hugo would otherwise render the zero date.

## Notes for review

- The redesign intentionally stays inside `layouts/` and `static/css/custom.css`; the theme itself is not modified.
- `taxonomy.html` branches on `.Kind` for both the tags index and individual tag pages. That kept the taxonomy redesign self-contained and matched how this site resolves those templates.
- Several small follow-up tweaks are included from live review of the sticky header and taxonomy pages, mainly around spacing, footer anchoring, and overlap while scrolling.

## Validation

- `hugo`